### PR TITLE
docs: example graphinder for graphql docker enum

### DIFF
--- a/cybersecurity/offensive/information-gathering/graphinder.yml
+++ b/cybersecurity/offensive/information-gathering/graphinder.yml
@@ -1,0 +1,19 @@
+description: Graphinder is a tool that extracts all GraphQL endpoints from a given domain.
+
+functions:
+  graphinder_url_scan:
+    description: Extract all GraphQL endpoints from a given domain.
+    parameters:
+      target:
+        type: string
+        description: The URL of the target to scan.
+        examples:
+          - https://graphql-pokemon.vercel.app/
+
+    container:
+      image: escapetech/graphinder
+
+    cmdline: # https://github.com/Escape-Technologies/graphinder
+      - graphinder
+      - --domain
+      - ${target}


### PR DESCRIPTION
example in-use:

```shell
➜  robopages-cli git:(docs/readme-docker-suggestion-v2) robopages run --function graphinder_url_scan
>> enter value for argument 'target': https://graphql-pokemon.vercel.app/

[2024-10-31T17:18:01Z WARN ] executing: /usr/local/bin/docker run --rm escapetech/graphinder --domain https://graphql-pokemon.vercel.app/
>> enter 'y' to proceed or any other key to cancel: y
```

<img width="1442" alt="image" src="https://github.com/user-attachments/assets/823ba9aa-9437-43cf-8784-014419d61f61">
