### PR TITLE
docs: katana example

### DIFF
--- a/cybersecurity/offensive/information-gathering/katana.yml
+++ b/cybersecurity/offensive/information-gathering/katana.yml
@@ -1,0 +1,60 @@
+description: Katana is a fast crawler focused on execution in automation pipelines offering both headless and non-headless crawling.
+
+functions:
+  katana_headless_crawler:
+    description: "Crawls a target or list of targets in headless mode"
+    parameters:
+      target:
+        type: string
+        description: "target url / list to crawl"
+        examples:
+          - https://target.tld
+          - https://tesla.com,https://google.com
+
+    container:
+      image: projectdiscovery/katana # https://github.com/projectdiscovery/katana
+      args:
+        - --net=host
+
+    cmdline:
+      - katana
+      - -u
+      - ${target}
+      - -system-chrome
+      - -headless
+      - -sb
+      - -jsonl
+
+  katana_proxied_crawler_scope:
+    description: "Crawls a target or list of targets with a proxy and defined crawl scope using regex"
+    parameters:
+      target:
+        type: string
+        description: "target url / list to crawl"
+        examples:
+          - https://target.tld
+          - https://tesla.com,https://google.com
+      proxy:
+        type: string
+        description: The upstream proxy dstip and dstport
+        examples:
+          - http://127.0.0.1:8080 # burp default
+      crawl_scope:
+        type: string
+        description: For advanced scope control, -cs option can be used that comes with regex support.
+        examples:
+          - login
+
+    container: # https://github.com/projectdiscovery/katana
+      image: projectdiscovery/katana
+      args:
+        - --net=host
+
+    cmdline:
+      - katana
+      - -u
+      - ${target}
+      - -proxy
+      - ${proxy}
+      - -cs
+      - ${crawl_scope}


### PR DESCRIPTION
example usage:

```shell
➜  .robopages robopages run --function katana_proxied_crawler_scope
>> enter value for argument 'crawl_scope': login

>> enter value for argument 'proxy': http://127.0.0.1:8080

>> enter value for argument 'target': https://target.tld

[2024-11-06T21:47:46Z WARN ] executing: /usr/local/bin/docker run --rm --net=host projectdiscovery/katana https://target.tld -proxy http://127.0.0.1:8080 -cs login
>> enter 'y' to proceed or any other key to cancel: y
```

or comma-separated targets:

<img width="1514" alt="image" src="https://github.com/user-attachments/assets/693b71b9-b3f7-45fe-8b70-cbaea73fffcb">


also @evilsocket FYI (just incase you weren't aware) that functions aren't parsed correctly when using `-` in the name :) apologies if this is a false alarm

ie: (when using `crawl-scope`) - it's probably my bad for missing something

```shell
➜  .robopages robopages run --function katana_proxied_crawler_scope
>> enter value for argument 'crawl-scope': login

>> enter value for argument 'proxy': http://127.0.0.1:8080

>> enter value for argument 'target': https://google.com

[2024-11-06T21:33:16Z WARN ] executing: /usr/local/bin/docker run --rm --net=host projectdiscovery/katana:latest -u https://google.com -proxy http://127.0.0.1:8080 -cs ${crawl-scope:}
```