### PR TITLE
fix: feroxb arch ref

### DIFF
--- a/cybersecurity/offensive/information-gathering/feroxbuster.yml
+++ b/cybersecurity/offensive/information-gathering/feroxbuster.yml
@@ -11,7 +11,7 @@ functions:
           - https://target.tld
 
     container:
-      platform: linux/arm64/v8
+      platform: linux/amd64
       image: epi052/feroxbuster
       args:
         - --net=host
@@ -37,7 +37,7 @@ functions:
           - http://127.0.0.1:8080 # burp default
 
     container:
-      platform: linux/arm64/v8
+      platform: linux/amd64
       image: epi052/feroxbuster
       args:
         - --net=host
@@ -67,7 +67,7 @@ functions:
           - http://127.0.0.1:8080 # burp default
 
     container:
-      platform: linux/arm64/v8
+      platform: linux/amd64
       image: epi052/feroxbuster
       args:
         - --net=host
@@ -96,7 +96,7 @@ functions:
           - http://127.0.0.1:8080 # burp default
 
     container:
-      platform: linux/arm64/v8
+      platform: linux/amd64
       image: epi052/feroxbuster
       args:
         - --net=host


### PR DESCRIPTION
my apologies, not sure why i didn't run into this in #12 

```shell
# before change:

➜  .robopages robopages serve                                        
[2024-11-07T00:11:14Z INFO ] pre building container for function trufflehog_scan ...
[2024-11-07T00:11:15Z INFO ] pre building container for function python_exec ...
[2024-11-07T00:11:15Z INFO ] pre building container for function virustotal_hash_lookup ...
[2024-11-07T00:11:15Z INFO ] pre building container for function amass_enum ...
[2024-11-07T00:11:15Z INFO ] pre building container for function amass_intel ...
[2024-11-07T00:11:15Z INFO ] pre building container for function arjun_http_method_target_scan ...
[2024-11-07T00:11:15Z INFO ] pre building container for function arjun_target_scan ...
[2024-11-07T00:11:16Z INFO ] pre building container for function arjun_target_scan_osint ...
[2024-11-07T00:11:16Z INFO ] pre building container for function enum_host_subdomains ...
[2024-11-07T00:11:16Z INFO ] pre building container for function feroxbuster_bruteforce_file_extensions ...
[2024-11-07T00:11:16Z INFO ] Using default tag: latest
[2024-11-07T00:11:16Z INFO ] Error response from daemon: no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest: not found
[2024-11-07T00:11:16Z ERROR] command failed with status: ExitStatus(unix_wait_status(256))

# following change:

➜  .robopages robopages serve
[2024-11-07T00:13:50Z INFO ] pre building container for function trufflehog_scan ...
[2024-11-07T00:13:50Z INFO ] pre building container for function python_exec ...
[2024-11-07T00:13:50Z INFO ] pre building container for function virustotal_hash_lookup ...
[2024-11-07T00:13:50Z INFO ] pre building container for function amass_enum ...
[2024-11-07T00:13:50Z INFO ] pre building container for function amass_intel ...
[2024-11-07T00:13:50Z INFO ] pre building container for function arjun_http_method_target_scan ...
[2024-11-07T00:13:50Z INFO ] pre building container for function arjun_target_scan ...
[2024-11-07T00:13:50Z INFO ] pre building container for function arjun_target_scan_osint ...
[2024-11-07T00:13:50Z INFO ] pre building container for function enum_host_subdomains ...
[2024-11-07T00:13:50Z INFO ] pre building container for function feroxbuster_bruteforce_file_extensions ...
[2024-11-07T00:13:50Z INFO ] pre building container for function feroxbuster_burp_bruteforce_file_extensions ...
[2024-11-07T00:13:50Z INFO ] pre building container for function feroxbuster_burp_extract_links_from_responses ...
[2024-11-07T00:13:50Z INFO ] pre building container for function feroxbuster_burp_random_user_agent_scan ...
[2024-11-07T00:13:50Z INFO ] pre building container for function graphinder_url_scan ...
[2024-11-07T00:13:50Z INFO ] pre building container for function httpx_tech_detect ...
[2024-11-07T00:13:50Z INFO ] pre building container for function katana_headless_crawler ...
[2024-11-07T00:13:50Z INFO ] pre building container for function katana_proxied_crawler_scope ...
[2024-11-07T00:13:50Z INFO ] pre building container for function nmap_tcp_ports_syn_scan ...
[2024-11-07T00:13:50Z INFO ] building image 'nmap_local' from '/Users/ads/.robopages/robopages-main/cybersecurity/offensive/information-gathering/nmap.Dockerfile'
[2024-11-07T00:13:51Z INFO ] sha256:12160dfe465c386187d439c19c238237ab383fa7a22c6b7bec86fb463c1ead5f
[2024-11-07T00:13:51Z INFO ] pre building container for function nmap_udp_ports_scan ...
[2024-11-07T00:13:51Z INFO ] building image 'nmap_local' from '/Users/ads/.robopages/robopages-main/cybersecurity/offensive/information-gathering/nmap.Dockerfile'
[2024-11-07T00:13:52Z INFO ] sha256:71a9b6fc58544f689c6e1c0a00569207576a6f47803a036d97f4d1bd569def31
[2024-11-07T00:13:52Z INFO ] pre building container for function nikto_scan ...
[2024-11-07T00:13:52Z INFO ] pre building container for function nuclei_basic_scan ...
[2024-11-07T00:13:52Z INFO ] pre building container for function nuclei_severity_scan ...
[2024-11-07T00:13:52Z INFO ] pre building container for function nuclei_tag_template_scan ...
[2024-11-07T00:13:52Z INFO ] pre building container for function sqlmap_scan ...
[2024-11-07T00:13:52Z INFO ] pre building container for function wpscan_scan ...
[2024-11-07T00:13:52Z INFO ] pre building container for function wpscan_scan_stealthy ...
[2024-11-07T00:13:52Z INFO ] pre building container for function http_get ...
[2024-11-07T00:13:52Z INFO ] pre building container for function http_post ...
[2024-11-07T00:13:52Z INFO ] serving 19 pages on http://127.0.0.1:8000 with 12 max running tasks
```