### PR TITLE
fix: workflow cannot find commit hashes

### DIFF
--- a/.github/workflows/validate_robopages.yml
+++ b/.github/workflows/validate_robopages.yml
@@ -48,8 +48,11 @@ jobs:
               dreadnode/robopages:latest validate --path "$(printf '%q' "$file")"
           }
 
+          # Fetch the base branch to ensure we have the commit history
+          git fetch origin ${{ github.base_ref }}
+
           # Get changed files, excluding .github directory
-          changed_files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | \
+          changed_files=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | \
             grep '\.yml$' | grep -v '^.github/' || true)
 
           # Validate each changed file


### PR DESCRIPTION
workflow currently not working as expected, [example](https://github.com/dreadnode/robopages/pull/15/checks)
i'm going to run some checks on this branch to ensure it's all good before merging