### PR TITLE
chore: backhaul categories for robopages

### DIFF
--- a/.github/workflows/validate_robopages.yml
+++ b/.github/workflows/validate_robopages.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # 3.7.1
 
+      - name: Install validation dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y binutils strings
+
       - name: Validate Contribution Files
         id: robopages-validation
         continue-on-error: true
@@ -44,13 +49,15 @@ jobs:
 
             docker pull dreadnode/robopages:latest
 
-            # Run validation with Docker socket mounted
+            # Run validation without Docker socket and skip container checks
             docker run --rm \
               -v $(pwd):/workspace \
-              -v /var/run/docker.sock:/var/run/docker.sock \
               -w /workspace \
-              --privileged \
-              dreadnode/robopages:latest validate --path "$(printf '%q' "$file")" --skip-docker
+              dreadnode/robopages:latest validate \
+                --path "$(printf '%q' "$file")" \
+                --skip-docker \
+                --skip-container-validation
+
           }
 
           # Get changed files using GitHub's provided variables

--- a/.github/workflows/validate_robopages.yml
+++ b/.github/workflows/validate_robopages.yml
@@ -25,11 +25,6 @@ jobs:
       - name: Set up Docker
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # 3.7.1
 
-      - name: Install validation dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y binutils strings
-
       - name: Validate Contribution Files
         id: robopages-validation
         continue-on-error: true
@@ -49,15 +44,13 @@ jobs:
 
             docker pull dreadnode/robopages:latest
 
-            # Run validation without Docker socket and skip container checks
+            # Run validation with Docker socket mounted
             docker run --rm \
               -v $(pwd):/workspace \
+              -v /var/run/docker.sock:/var/run/docker.sock \
               -w /workspace \
-              dreadnode/robopages:latest validate \
-                --path "$(printf '%q' "$file")" \
-                --skip-docker \
-                --skip-container-validation
-
+              --privileged \
+              dreadnode/robopages:latest validate --path "$(printf '%q' "$file")" --skip-docker
           }
 
           # Get changed files using GitHub's provided variables

--- a/.github/workflows/validate_robopages.yml
+++ b/.github/workflows/validate_robopages.yml
@@ -63,19 +63,21 @@ jobs:
             validate_file "$file" || exit 1
           done
 
-      - name: Post validation status
-        if: always()
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #7.0.1
-        with:
-          script: |
-            const validation_status = '${{ steps.robopages-validation.outcome }}' === 'success'
-              ? '✅ Validation successful'
-              : '❌ Validation failed';
+          - name: Post validation status
+          if: always()
+          uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #7.0.1
+          with:
+            script: |
+              const validation_status = '${{ steps.robopages-validation.outcome }}' === 'success'
+                ? '✅ Validation successful'
+                : '❌ Validation failed';
 
-            github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              body: `## Validation Results\n${validation_status}\n\nPlease ensure your contribution follows the required format.`,
-              event: 'COMMENT'
-            });
+              const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+
+              github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                body: `## Validation Results\n${validation_status}\n\nPlease ensure your contribution follows the required format.\n\n[View Run Details](${runUrl})`,
+                event: 'COMMENT'
+              });

--- a/.github/workflows/validate_robopages.yml
+++ b/.github/workflows/validate_robopages.yml
@@ -63,21 +63,32 @@ jobs:
             validate_file "$file" || exit 1
           done
 
-          - name: Post validation status
-          if: always()
-          uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #7.0.1
-          with:
-            script: |
-              const validation_status = '${{ steps.robopages-validation.outcome }}' === 'success'
-                ? '✅ Validation successful'
-                : '❌ Validation failed';
+      - name: Post validation status
+        if: always()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #7.0.1
+        with:
+          script: |
+            const validation_status = '${{ steps.robopages-validation.outcome }}' === 'success' ? '✅ Validation successful' : '❌ Validation failed';
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const timestamp = new Date().toISOString();
+            const body = [
+              `## Validation Results (${timestamp})`,
+              '',
+              validation_status,
+              '',
+              'Please ensure your contribution follows the required format.',
+              '',
+              `🔍 [View Full Validation Details](${runUrl})`,
+              '',
+              '---',
+              `Run ID: \`${process.env.GITHUB_RUN_ID}\``,
+              `Workflow: ${process.env.GITHUB_WORKFLOW}`
+            ].join('\n');
 
-              const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-
-              github.rest.pulls.createReview({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.issue.number,
-                body: `## Validation Results\n${validation_status}\n\nPlease ensure your contribution follows the required format.\n\n[View Run Details](${runUrl})`,
-                event: 'COMMENT'
-              });
+            github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              body: body,
+              event: 'COMMENT'
+            });

--- a/coding/python/exec.yml
+++ b/coding/python/exec.yml
@@ -1,5 +1,9 @@
 description: A set of functions to execute python code in various flavors.
 
+categories:
+  - coding
+  - python
+
 functions:
   python_exec:
     description: Execute python code.
@@ -14,10 +18,10 @@ functions:
           - 'import requests; print(requests.post("https://example.com", data={"key": "value"}).text)'
           - |
             import random
-            
+
             def generate_random_numbers(n):
                 return [random.randint(1, 100) for _ in range(n)]
-            
+
             numbers = generate_random_numbers(10)
             print(f"Generated numbers: {numbers}")
             print(f"Sum of numbers: {sum(numbers)}")

--- a/cybersecurity/cicd/trufflehog.yml
+++ b/cybersecurity/cicd/trufflehog.yml
@@ -1,10 +1,8 @@
 description: TruffleHog is the most powerful secrets Discovery, Classification, Validation, and Analysis tool. In this context secret refers to a credential a machine uses to authenticate itself to another machine. This includes API keys, database passwords, private encryption keys, and more.
 
 categories:
+  - cybersecurity
   - cicd
-  - secrets
-  - information-gathering
-  - reconnaissance
 
 functions:
   trufflehog_scan:

--- a/cybersecurity/cicd/trufflehog.yml
+++ b/cybersecurity/cicd/trufflehog.yml
@@ -1,5 +1,11 @@
 description: TruffleHog is the most powerful secrets Discovery, Classification, Validation, and Analysis tool. In this context secret refers to a credential a machine uses to authenticate itself to another machine. This includes API keys, database passwords, private encryption keys, and more.
 
+categories:
+  - cicd
+  - secrets
+  - information-gathering
+  - reconnaissance
+
 functions:
   trufflehog_scan:
     description: Scan a GitHub repository for secrets using TruffleHog.

--- a/cybersecurity/defensive/incident-response/splunk.yml
+++ b/cybersecurity/defensive/incident-response/splunk.yml
@@ -1,9 +1,9 @@
 description: Splunk is a platform for searching, monitoring, and analyzing machine-generated big data via a web-style interface.
 
 categories:
+  - cybersecurity
+  - defensive
   - incident-response
-  - logging
-  - monitoring
 
 functions:
   splunk_search:

--- a/cybersecurity/defensive/incident-response/splunk.yml
+++ b/cybersecurity/defensive/incident-response/splunk.yml
@@ -1,5 +1,10 @@
 description: Splunk is a platform for searching, monitoring, and analyzing machine-generated big data via a web-style interface.
 
+categories:
+  - incident-response
+  - logging
+  - monitoring
+
 functions:
   splunk_search:
     description: Perform a search query on Splunk.

--- a/cybersecurity/defensive/malware/virustotal.yml
+++ b/cybersecurity/defensive/malware/virustotal.yml
@@ -1,5 +1,11 @@
 description: Analyse suspicious files, domains, IPs and URLs to detect malware and other breaches, automatically share them with the security community. You will require a VT API key to use this robopage.
 
+categories:
+  - incident-response
+  - binary-analysis
+  - malware-analysis
+  - forensics
+
 functions:
   virustotal_hash_lookup:
     description: Lookup a given hash with VirusTotal.

--- a/cybersecurity/defensive/malware/virustotal.yml
+++ b/cybersecurity/defensive/malware/virustotal.yml
@@ -1,10 +1,9 @@
 description: Analyse suspicious files, domains, IPs and URLs to detect malware and other breaches, automatically share them with the security community. You will require a VT API key to use this robopage.
 
 categories:
-  - incident-response
-  - binary-analysis
-  - malware-analysis
-  - forensics
+  - cybersecurity
+  - defensive
+  - malware
 
 functions:
   virustotal_hash_lookup:

--- a/cybersecurity/offensive/information-gathering/amass.yml
+++ b/cybersecurity/offensive/information-gathering/amass.yml
@@ -1,9 +1,9 @@
 description: The OWASP Amass Project performs network mapping of attack surfaces and external asset discovery using open source information gathering and active reconnaissance techniques.
 
 categories:
+  - cybersecurity
+  - offensive
   - information-gathering
-  - reconnaissance
-  - dns-enumeration
 
 functions:
   amass_enum:

--- a/cybersecurity/offensive/information-gathering/arjun.yml
+++ b/cybersecurity/offensive/information-gathering/arjun.yml
@@ -1,9 +1,9 @@
 description: Web applications use parameters (or queries) to accept user input. Arjun finds valid HTTP parameters with a huge default dictionary of 10,985 parameter names.
 
 categories:
+  - cybersecurity
+  - offensive
   - information-gathering
-  - reconnaissance
-  - osint
 
 functions:
   arjun_target_scan:

--- a/cybersecurity/offensive/information-gathering/arjun.yml
+++ b/cybersecurity/offensive/information-gathering/arjun.yml
@@ -1,5 +1,10 @@
 description: Web applications use parameters (or queries) to accept user input. Arjun finds valid HTTP parameters with a huge default dictionary of 10,985 parameter names.
 
+categories:
+  - information-gathering
+  - reconnaissance
+  - osint
+
 functions:
   arjun_target_scan:
     description: Run Arjun against a single target.

--- a/cybersecurity/offensive/information-gathering/dns-enumeration.yml
+++ b/cybersecurity/offensive/information-gathering/dns-enumeration.yml
@@ -1,5 +1,10 @@
 description: This page uses Legba for DNS enumeration.
 
+categories:
+  - information-gathering
+  - reconnaissance
+  - dns-enumeration
+
 functions:
   enum_host_subdomains:
     description: Enumerate subdomains of a target host.

--- a/cybersecurity/offensive/information-gathering/dns-enumeration.yml
+++ b/cybersecurity/offensive/information-gathering/dns-enumeration.yml
@@ -1,9 +1,10 @@
 description: This page uses Legba for DNS enumeration.
 
 categories:
+  - cybersecurity
+  - offensive
   - information-gathering
-  - reconnaissance
-  - dns-enumeration
+
 
 functions:
   enum_host_subdomains:

--- a/cybersecurity/offensive/information-gathering/feroxbuster.yml
+++ b/cybersecurity/offensive/information-gathering/feroxbuster.yml
@@ -1,5 +1,10 @@
 description: feroxbuster is a tool designed to perform Forced Browsing. Forced browsing is an attack where the aim is to enumerate and access resources that are not referenced by the web application, but are still accessible by an attacker.
 
+categories:
+  - information-gathering
+  - reconnaissance
+  - http
+
 functions:
   feroxbuster_bruteforce_file_extensions:
     description: "Brute-forces .pdf, .js, .html, .php, .txt, .json, and .docx lookups to each target with Burp proxy."

--- a/cybersecurity/offensive/information-gathering/feroxbuster.yml
+++ b/cybersecurity/offensive/information-gathering/feroxbuster.yml
@@ -1,9 +1,9 @@
 description: feroxbuster is a tool designed to perform Forced Browsing. Forced browsing is an attack where the aim is to enumerate and access resources that are not referenced by the web application, but are still accessible by an attacker.
 
 categories:
+  - cybersecurity
+  - offensive
   - information-gathering
-  - reconnaissance
-  - http
 
 functions:
   feroxbuster_bruteforce_file_extensions:

--- a/cybersecurity/offensive/information-gathering/graphinder.yml
+++ b/cybersecurity/offensive/information-gathering/graphinder.yml
@@ -1,5 +1,10 @@
 description: Graphinder is a tool that extracts all GraphQL endpoints from a given domain.
 
+categories:
+  - information-gathering
+  - reconnaissance
+  - graphql
+
 functions:
   graphinder_url_scan:
     description: Extract all GraphQL endpoints from a given domain.

--- a/cybersecurity/offensive/information-gathering/graphinder.yml
+++ b/cybersecurity/offensive/information-gathering/graphinder.yml
@@ -1,9 +1,9 @@
 description: Graphinder is a tool that extracts all GraphQL endpoints from a given domain.
 
 categories:
+  - cybersecurity
+  - offensive
   - information-gathering
-  - reconnaissance
-  - graphql
 
 functions:
   graphinder_url_scan:

--- a/cybersecurity/offensive/information-gathering/httpx.yml
+++ b/cybersecurity/offensive/information-gathering/httpx.yml
@@ -1,5 +1,10 @@
 description: httpx is a fast and multi-purpose HTTP toolkit that allows running multiple probes using the retryablehttp library. It is designed to maintain result reliability with an increased number of threads.
 
+categories:
+  - information-gathering
+  - reconnaissance
+  - http
+
 functions:
   httpx_tech_detect:
     description: Run multiple HTTP probes on a target to fingerprint the web technology stack.

--- a/cybersecurity/offensive/information-gathering/httpx.yml
+++ b/cybersecurity/offensive/information-gathering/httpx.yml
@@ -1,9 +1,9 @@
 description: httpx is a fast and multi-purpose HTTP toolkit that allows running multiple probes using the retryablehttp library. It is designed to maintain result reliability with an increased number of threads.
 
 categories:
+  - cybersecurity
+  - offensive
   - information-gathering
-  - reconnaissance
-  - http
 
 functions:
   httpx_tech_detect:

--- a/cybersecurity/offensive/information-gathering/katana.yml
+++ b/cybersecurity/offensive/information-gathering/katana.yml
@@ -1,9 +1,9 @@
 description: Katana is a fast crawler focused on execution in automation pipelines offering both headless and non-headless crawling.
 
 categories:
+  - cybersecurity
+  - offensive
   - information-gathering
-  - reconnaissance
-  - crawler
 
 functions:
   katana_headless_crawler:

--- a/cybersecurity/offensive/information-gathering/katana.yml
+++ b/cybersecurity/offensive/information-gathering/katana.yml
@@ -1,5 +1,10 @@
 description: Katana is a fast crawler focused on execution in automation pipelines offering both headless and non-headless crawling.
 
+categories:
+  - information-gathering
+  - reconnaissance
+  - crawler
+
 functions:
   katana_headless_crawler:
     description: "Crawls a target or list of targets in headless mode"

--- a/cybersecurity/offensive/information-gathering/nmap.yml
+++ b/cybersecurity/offensive/information-gathering/nmap.yml
@@ -3,6 +3,11 @@ description: >
   The output from Nmap is a list of scanned targets, with supplemental information on each depending on the options used. Key among that information is the "interesting ports table".. That table lists the port number and protocol, service name, and state. The state is either open, filtered, closed, or unfiltered. Open. means that an application on the target machine is listening for connections/packets on that port. Filtered. means that a firewall, filter, or other network obstacle is blocking the port so that Nmap cannot tell whether it is open or closed. Closed. ports have no application listening on them, though they could open up at any time. Ports are classified as unfiltered. when they are responsive to Nmap's probes, but Nmap cannot determine whether they are open or closed. Nmap reports the state combinations open|filtered. and closed|filtered. when it cannot determine which of the two states describe a port. The port table may also include software version details when version detection has been requested. When an IP protocol scan is requested (-sO), Nmap provides information on supported IP protocols rather than listening ports.
   In addition to the interesting ports table, Nmap can provide further information on targets, including reverse DNS names, operating system guesses, device types, and MAC addresses.
 
+categories:
+  - information-gathering
+  - reconnaissance
+  - networking
+
 functions:
   nmap_tcp_ports_syn_scan:
     description: Scan one or more targets for the list of common TCP ports using a TCP SYN scan.
@@ -16,7 +21,7 @@ functions:
           - scanme.nmap.org
 
     container:
-      build: 
+      build:
         path: ${cwd}/nmap.Dockerfile
         name: nmap_local
       args:
@@ -44,7 +49,7 @@ functions:
           - scanme.nmap.org
 
     container:
-      build: 
+      build:
         path: ${cwd}/nmap.Dockerfile
         name: nmap_local
       args:
@@ -57,4 +62,4 @@ functions:
       - nmap
       - -sU
       - -A
-      - ${target}      
+      - ${target}

--- a/cybersecurity/offensive/information-gathering/nmap.yml
+++ b/cybersecurity/offensive/information-gathering/nmap.yml
@@ -4,9 +4,9 @@ description: >
   In addition to the interesting ports table, Nmap can provide further information on targets, including reverse DNS names, operating system guesses, device types, and MAC addresses.
 
 categories:
+  - cybersecurity
+  - offensive
   - information-gathering
-  - reconnaissance
-  - networking
 
 functions:
   nmap_tcp_ports_syn_scan:

--- a/cybersecurity/offensive/web-exploitation/nikto.yml
+++ b/cybersecurity/offensive/web-exploitation/nikto.yml
@@ -1,5 +1,10 @@
 description: Scan web server for known vulnerabilities.
 
+categories:
+  - web-exploitation
+  - reconnaissance
+  - http
+
 functions:
   nikto_scan:
     description: Scan a specific target web server for known vulnerabilities.

--- a/cybersecurity/offensive/web-exploitation/nikto.yml
+++ b/cybersecurity/offensive/web-exploitation/nikto.yml
@@ -1,9 +1,9 @@
 description: Scan web server for known vulnerabilities.
 
 categories:
+  - cybersecurity
+  - offensive
   - web-exploitation
-  - reconnaissance
-  - http
 
 functions:
   nikto_scan:

--- a/cybersecurity/offensive/web-exploitation/nuclei.yml
+++ b/cybersecurity/offensive/web-exploitation/nuclei.yml
@@ -1,5 +1,10 @@
 description: Nuclei is a modern, high-performance vulnerability scanner that leverages simple YAML-based templates. It empowers you to design custom vulnerability detection scenarios that mimic real-world conditions, leading to zero false positives.
 
+categories:
+  - web-exploitation
+  - reconnaissance
+  - http
+
 functions:
   nuclei_basic_scan:
     description: Default templates on a single target

--- a/cybersecurity/offensive/web-exploitation/nuclei.yml
+++ b/cybersecurity/offensive/web-exploitation/nuclei.yml
@@ -1,9 +1,9 @@
 description: Nuclei is a modern, high-performance vulnerability scanner that leverages simple YAML-based templates. It empowers you to design custom vulnerability detection scenarios that mimic real-world conditions, leading to zero false positives.
 
 categories:
+  - cybersecurity
+  - offensive
   - web-exploitation
-  - reconnaissance
-  - http
 
 functions:
   nuclei_basic_scan:

--- a/cybersecurity/offensive/web-exploitation/sqlmap.yml
+++ b/cybersecurity/offensive/web-exploitation/sqlmap.yml
@@ -1,5 +1,11 @@
 description: Automatic SQL injection tool.
 
+categories:
+  - web-exploitation
+  - reconnaissance
+  - sql
+  - injection
+
 functions:
   sqlmap_scan:
     description: Scan a specific target for SQL injection vulnerabilities.

--- a/cybersecurity/offensive/web-exploitation/sqlmap.yml
+++ b/cybersecurity/offensive/web-exploitation/sqlmap.yml
@@ -1,10 +1,9 @@
 description: Automatic SQL injection tool.
 
 categories:
+  - cybersecurity
+  - offensive
   - web-exploitation
-  - reconnaissance
-  - sql
-  - injection
 
 functions:
   sqlmap_scan:

--- a/cybersecurity/offensive/web-exploitation/wpscan.yml
+++ b/cybersecurity/offensive/web-exploitation/wpscan.yml
@@ -1,6 +1,12 @@
 description: WPScan scans for vulnerabilities in websites running WordPress.
 # https://wpscan.com/blog/wpscan-cli-cheat-sheet-poster/
 
+categories:
+  - web-exploitation
+  - reconnaissance
+  - http
+  - wordpress
+
 functions:
   wpscan_scan:
     description: Scan a specific domain for WordPress plugins with vulnerabilities.
@@ -34,7 +40,7 @@ functions:
       image: wpscanteam/wpscan
       args:
         - --net=host
-    
+
     cmdline:
       - wpscan
       - --url

--- a/cybersecurity/offensive/web-exploitation/wpscan.yml
+++ b/cybersecurity/offensive/web-exploitation/wpscan.yml
@@ -2,10 +2,9 @@ description: WPScan scans for vulnerabilities in websites running WordPress.
 # https://wpscan.com/blog/wpscan-cli-cheat-sheet-poster/
 
 categories:
+  - cybersecurity
+  - offensive
   - web-exploitation
-  - reconnaissance
-  - http
-  - wordpress
 
 functions:
   wpscan_scan:

--- a/cybersecurity/reverse-engineering/strings.yml
+++ b/cybersecurity/reverse-engineering/strings.yml
@@ -19,6 +19,9 @@ functions:
           - /path/to/binary
           - /Applications/Firefox.app/Contents/MacOS/firefox
 
+    container:
+      image: alpine
+
     cmdline:
-      - strings
+      - /usr/bin/strings
       - ${file_path}

--- a/cybersecurity/reverse-engineering/strings.yml
+++ b/cybersecurity/reverse-engineering/strings.yml
@@ -1,10 +1,9 @@
 description: The best reverse engineering tool that's ever been created.
 
 categories:
+  - cybersecurity
+  - offensive
   - reverse-engineering
-  - binary-analysis
-  - malware-analysis
-  - forensics
 
 functions:
   print_strings_in_file:

--- a/cybersecurity/reverse-engineering/strings.yml
+++ b/cybersecurity/reverse-engineering/strings.yml
@@ -1,4 +1,7 @@
-description: The best reverse engineering tool that's ever been created.
+description: |
+  The best reverse engineering tool that's ever been created.
+  Strings looks for ASCII strings in a binary file or standard input.  Strings is useful for identifying random object files and many other things.  A string is any sequence of 4 (the default) or
+  more printing characters [ending at, but not including, any other character or EOF].
 
 categories:
   - cybersecurity
@@ -17,5 +20,5 @@ functions:
           - /Applications/Firefox.app/Contents/MacOS/firefox
 
     cmdline:
-      - /usr/bin/strings
+      - strings
       - ${file_path}

--- a/cybersecurity/reverse-engineering/strings.yml
+++ b/cybersecurity/reverse-engineering/strings.yml
@@ -1,12 +1,4 @@
-description: |
-  The best reverse engineering tool that's ever been created.
-  Strings looks for ASCII strings in a binary file or standard input.  Strings is useful for identifying random object files and many other things.  A string is any sequence of 4 (the default) or
-  more printing characters [ending at, but not including, any other character or EOF].
-
-categories:
-  - cybersecurity
-  - offensive
-  - reverse-engineering
+description: The best reverse engineering tool that's ever been created.
 
 functions:
   print_strings_in_file:
@@ -18,9 +10,6 @@ functions:
         examples:
           - /path/to/binary
           - /Applications/Firefox.app/Contents/MacOS/firefox
-
-    container:
-      image: alpine
 
     cmdline:
       - /usr/bin/strings

--- a/cybersecurity/reverse-engineering/strings.yml
+++ b/cybersecurity/reverse-engineering/strings.yml
@@ -1,5 +1,11 @@
 description: The best reverse engineering tool that's ever been created.
 
+categories:
+  - reverse-engineering
+  - binary-analysis
+  - malware-analysis
+  - forensics
+
 functions:
   print_strings_in_file:
     description: Find the printable strings in a file.

--- a/cybersecurity/reverse-engineering/symbols.yml
+++ b/cybersecurity/reverse-engineering/symbols.yml
@@ -1,5 +1,10 @@
 description: Function to print exported and imported symbols from a binary.
 
+categories:
+  - cybersecurity
+  - offensive
+  - reverse-engineering
+
 functions:
   print_exported_symbols_in_file:
     description: Find the exported symbols in an executable file or a library.

--- a/cybersecurity/reverse-engineering/symbols.yml
+++ b/cybersecurity/reverse-engineering/symbols.yml
@@ -1,5 +1,11 @@
 description: Function to print exported and imported symbols from a binary.
 
+categories:
+  - reverse-engineering
+  - binary-analysis
+  - malware-analysis
+  - forensics
+
 functions:
   print_exported_symbols_in_file:
     description: Find the exported symbols in an executable file or a library.

--- a/cybersecurity/reverse-engineering/symbols.yml
+++ b/cybersecurity/reverse-engineering/symbols.yml
@@ -1,10 +1,5 @@
 description: Function to print exported and imported symbols from a binary.
 
-categories:
-  - cybersecurity
-  - offensive
-  - reverse-engineering
-
 functions:
   print_exported_symbols_in_file:
     description: Find the exported symbols in an executable file or a library.

--- a/cybersecurity/reverse-engineering/symbols.yml
+++ b/cybersecurity/reverse-engineering/symbols.yml
@@ -1,10 +1,9 @@
 description: Function to print exported and imported symbols from a binary.
 
 categories:
+  - cybersecurity
+  - offensive
   - reverse-engineering
-  - binary-analysis
-  - malware-analysis
-  - forensics
 
 functions:
   print_exported_symbols_in_file:

--- a/utilities/web.yml
+++ b/utilities/web.yml
@@ -2,8 +2,6 @@ description: A set of web related utilities.
 
 categories:
   - utilities
-  - web
-  - http
 
 functions:
   http_get:

--- a/utilities/web.yml
+++ b/utilities/web.yml
@@ -1,5 +1,10 @@
 description: A set of web related utilities.
 
+categories:
+  - utilities
+  - web
+  - http
+
 functions:
   http_get:
     description: Perform an HTTP GET request to a given URL.


### PR DESCRIPTION
**Update:** agreed w Simon to update the workflow only for this PR and leave the categories as they are optional 

<!--in PR #14, specifically [this](https://github.com/dreadnode/robopages/pull/16/commits/a2166a85f8d2768762200ee060e1a4f5161fe9b3) commit

> i also need to cleanup some robopages missing the categories at the root

TLDR; add categories to the existing robopages, my oversight when submitting these entry submissions earlier and apologies :) 

to be 100% sure, i plan to import these into my local `.robopages/robopages-main` and `validate` and `serve`-->