### PR TITLE
chore: basic issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: Create a report to help improve robopages
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+### Bug Description
+A clear and concise description of the bug.
+
+### Steps to Reproduce
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### Expected Behavior
+A clear description of what you expected to happen.
+
+### Screenshots
+If applicable, add screenshots to help explain your problem.
+
+### Environment
+- OS: [e.g. Windows 10, macOS 12.0]
+- Browser: [e.g. Chrome 96]
+- Extension Version: [e.g. 1.0.0]
+- URL being tested: [if applicable]
+
+### Additional Context
+Add any other context about the problem here.
+
+### Console Output
+```
+Paste any relevant console output here
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Suggest an idea for robopages
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+### Problem Description
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+### Proposed Solution
+A clear and concise description of what you want to happen.
+
+### Alternative Solutions
+A clear and concise description of any alternative solutions or features you've considered.
+
+### Use Case
+Describe how this feature would be used and who would use it.
+
+### Additional Context
+Add any other context, screenshots, or mock-ups about the feature request here.
+
+### Implementation Ideas
+If you have any thoughts on how this could be implemented, share them here.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,90 @@
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Editor/IDE files
+.idea/
+.vscode/
+*.swp
+*.swo
+*.swn
+*~
+
+# Build artifacts
+*.exe
+*.out
+*.test
+*.prof
+bin/
+dist/
+
+# Docker
+.docker/
+*.env
+
+# Go specific
+*.o
+*.a
+*.so
+go.work
+
+# Python specific
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# CI/CD artifacts
+.coverage
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Logs
+*.log
+logs/
+log/
+
+# Temporary files
+tmp/
+temp/
+.tmp/
+*.tmp
+
+# Local configuration
+config.local.yml
+.env
+.env.local
+.env.*.local
+
+# Test files
+test/tmp/
+test/temp/
+coverage/
+
+# Project specific
+robopages.db
+*.db


### PR DESCRIPTION
small non-intrusive and optional (to the code) PR to add some issue templates for easier interaction with the project for first time users, feature requests etc
also noticed we were missing a basic `.gitignore`