### PR TITLE
feat: gowitness robopage

### DIFF
--- a/cybersecurity/offensive/information-gathering/gowitness.Dockerfile
+++ b/cybersecurity/offensive/information-gathering/gowitness.Dockerfile
@@ -1,0 +1,42 @@
+FROM golang:1-bookworm AS build
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone and build gowitness
+RUN git clone https://github.com/sensepost/gowitness.git /src
+WORKDIR /src
+
+# Build frontend and backend
+RUN cd web/ui && \
+    npm install && \
+    npm run build && \
+    cd ../..
+
+RUN go install github.com/swaggo/swag/cmd/swag@latest && \
+    swag i --exclude ./web/ui --output web/docs && \
+    CGO_ENABLED=0 go build -v -trimpath -ldflags="-s -w" -o gowitness
+
+FROM debian:bookworm-slim
+
+# Install Chromium and other dependencies
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    chromium \
+    chromium-driver \
+    dumb-init \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy built binary from build stage
+COPY --from=build /src/gowitness /usr/local/bin/gowitness
+
+# Set Chrome path for gowitness
+ENV CHROME_PATH=/usr/bin/chromium
+
+VOLUME ["/screenshots"]
+WORKDIR /screenshots
+
+ENTRYPOINT ["dumb-init", "--", "gowitness"]

--- a/cybersecurity/offensive/information-gathering/gowitness.yml
+++ b/cybersecurity/offensive/information-gathering/gowitness.yml
@@ -1,0 +1,33 @@
+description: >
+  Gowitness is a website screenshot utility written in Go that uses Chrome's rendering engine to capture web interface screenshots during reconnaissance.
+
+functions:
+  gowitness_single:
+    description: Capture a screenshot of a single URL.
+    parameters:
+      target:
+        type: string
+        description: The URL to capture.
+        examples:
+          - https://example.com
+
+    container:
+      platform: linux/amd64
+      build:
+        path: ${cwd}/gowitness.Dockerfile
+        name: gowitness_local
+      args:
+        - --net=host
+      volumes:
+        - ${cwd}/screenshots:/screenshots
+
+    cmdline:
+      - gowitness
+      - scan
+      - single
+      - --url
+      - ${target}
+      - --screenshot-path
+      - /screenshots
+      - --write-jsonl
+      - --write-screenshots


### PR DESCRIPTION
i chose to build the container locally to allow platform control and since this is only available on `gchr://`
also raised an issue RE the workflow failing on FPs which ill tackle separately :) 

```bash
robopages run --function gowitness_single
>> enter value for argument 'target': https://dreadnode.io

[2025-02-05T22:04:41Z INFO ] building image 'gowitness_local' from '/Users/ads/.robopages/robopages-main/cybersecurity/offensive/information-gathering/gowitness.Dockerfile'
[2025-02-05T22:04:42Z INFO ] sha256:6a3778464f3aac674808bc844cd7a6f23404bf4ebb27d6d02b950b07ef589fb4
[2025-02-05T22:04:42Z WARN ] executing: /usr/local/bin/docker run --rm -v/Users/ads/.robopages/robopages-main/cybersecurity/offensive/information-gathering/screenshots:/screenshots --net=host gowitness_local scan single --url https://dreadnode.io --screenshot-path /screenshots --write-jsonl --write-screenshots
>> enter 'y' to proceed or any other key to cancel: y

2025/02/05 22:04:50 INFO result 🤖 target=https://dreadnode.io status-code=200 title=dreadnode have-screenshot=true
```

```bash
# ls -al
total 52
drwxr-xr-x 2 root root  4096 Feb  5 22:01 .
drwxr-xr-x 3 root root  4096 Feb  5 22:03 ..
-rw-r--r-- 1 root root 42175 Feb  5 22:03 https---crucible.dreadnode.io.jpeg
# pwd
/data/screenshots
```

kinda playing around with the idea of filesystem sharing (as per Slack) and the beauty of hooking in nerve to this

## AI-Generated Summary

Summary of changes to add Gowitness tool support:

- Introduced a new Dockerfile for building and running Gowitness.
  - Base image is `golang:1-bookworm` for building the application.
  - Installs dependencies like Git and npm for building the frontend.
  - Clones the Gowitness repository and builds both frontend and backend.
  - Final image based on `debian:bookworm-slim`, installing Chromium and related packages.
  - Sets up the environment for execution, defining Chrome path and working directory.

- Added a new YAML configuration file for Gowitness.
  - Describes Gowitness as a utility for capturing website screenshots using Chrome.
  - Defines a function `gowitness_single` for capturing a screenshot of a single URL.
  - Includes parameters for specifying the target URL and setting up container configurations.
  - Provides command-line examples for usage.

Potential impacts:
- Enables automated website reconnaissance capabilities.
- Streamlines the setup and usage of the Gowitness tool with Docker integration.

---

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
