### PR TITLE
fix: subfinder not subjack

### DIFF
--- a/cybersecurity/offensive/information-gathering/subfinder.yml
+++ b/cybersecurity/offensive/information-gathering/subfinder.yml
@@ -1,8 +1,8 @@
 description: >
-  Subjacker is a tool for hijacking subdomains. It can be used to find and take over subdomains that are no longer in use or have been abandoned by their owners. This can be useful for security researchers, penetration testers, and bug bounty hunters who want to identify potential vulnerabilities in a target's infrastructure.
+  subfinder is a subdomain discovery tool that returns valid subdomains for websites, using passive online sources. It has a simple, modular architecture and is optimized for speed. subfinder is built for doing one thing only - passive subdomain enumeration, and it does that very well.
 
 functions:
-  subjack_enum_host_subdomains:
+  subfinder_enum_host_subdomains:
     description: Enumerate subdomains of a target host.
     parameters:
       target:


### PR DESCRIPTION
totally mb, brain fog moment for a second

relates to #34 and https://github.com/dreadnode/robopages-cli/pull/24#issuecomment-2789847035

## AI-Generated Summary

- Renamed file from `subjacker.yml` to `subfinder.yml`.
- Updated tool description to reflect accurate functionality:
  - Changed from hijacking abandoned subdomains to passive subdomain discovery.
  - Clarified that `subfinder` uses passive online sources for subdomain enumeration.
- Updated function name in the YAML file from `subjack_enum_host_subdomains` to `subfinder_enum_host_subdomains`.
- These changes ensure the file correctly describes the purpose and functionality of the `subfinder` tool, improving clarity for future users.

---

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
